### PR TITLE
Add Lao dictionaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,16 @@ pixivSummaries.json
 
 Cifu-v1.txt
 *.zip
+
+# MacOS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Emacs generated file #
+*.*~

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ My related dictionary resources:
   - [Japanese-Mongolian/日・モ辞典](#japanese-mongolian日モ辞典)
   - [Korean](#korean)
   - [Vietnamese-English](#vietnamese-english)
-  - [Lao](#Lao)
+  - [Lao](#lao)
   - [English-English](#english-english)
   - [Other Languages](#other-languages)
 
@@ -1447,21 +1447,27 @@ entries.
 
 ## Lao
 
-Note that ISO code for Lao is `lo`, please consult [List of ISO 639 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) for clearification.
+Note that ISO code for Lao is `lo`, please consult
+[List of ISO 639 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) for
+clearification.
 
-### Lao-Lao
+#### Lao-Lao
 
 **[Maha Sila Viravongs 1960 Lao Dictionary](https://small.fileditchstuff.me/s11/jOxxQtOcoZsodMtnujj.zip)**
 
 [SEAlang Project](http://sealang.net/faq/) described it as below.
 
-Maha Sila Viravongs' Dictionary of the Lao Language (Watcananukom Phaasaa Laaw), first published by the Ministry of Education in 1960, stands as the singular achievement of Lao lexicography. 
+Maha Sila Viravongs' Dictionary of the Lao Language (Watcananukom Phaasaa Laaw), first published by
+the Ministry of Education in 1960, stands as the singular achievement of Lao lexicography.
 
-Far more than a simple compendium of definitions, Sila 1960 is filled with etymologies and citations, and includes some 11,500 heads, and nearly 24,000 subentries.
+Far more than a simple compendium of definitions, Sila 1960 is filled with etymologies and
+citations, and includes some 11,500 heads, and nearly 24,000 subentries.
 
-The value of Sila 1960 continues to grow following the 1975 policy of spelling simplification.  This dictionary provides both a necessary reference for earlier literature (including Sila's own History of Laos), as well as the first scholarly refernece to the dvelopment of the Lao language.
+The value of Sila 1960 continues to grow following the 1975 policy of spelling simplification. This
+dictionary provides both a necessary reference for earlier literature (including Sila's own History
+of Laos), as well as the first scholarly refernece to the dvelopment of the Lao language.
 
-### Lao-English
+#### Lao-English
 
 **[Lao-Eng Dictionary](https://small.fileditchstuff.me/s11/BgEJUJaYRMiiMVOfveZn.zip)**
 

--- a/readme.md
+++ b/readme.md
@@ -1444,6 +1444,26 @@ Vie-Vie dictionary converted by Marsh Nguyễn. The dictionary data is from Từ
 Dụng and was sourced from https://github.com/vntk/dictionary/tree/master/data contains 42012
 entries.
 
+## Lao
+
+Note that ISO code for Lao is `lo`, please consult [List of ISO 639 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) for clearification.
+
+### Lao-Lao
+
+**[Maha Sila Viravongs 1960 Lao Dictionary](https://small.fileditchstuff.me/s11/jOxxQtOcoZsodMtnujj.zip)**
+
+(SEAlang Project)[http://sealang.net/faq/] described it as below.
+
+Maha Sila Viravongs' Dictionary of the Lao Language (Watcananukom Phaasaa Laaw), first published by the Ministry of Education in 1960, stands as the singular achievement of Lao lexicography. 
+
+Far more than a simple compendium of definitions, Sila 1960 is filled with etymologies and citations, and includes some 11,500 heads, and nearly 24,000 subentries.
+
+The value of Sila 1960 continues to grow following the 1975 policy of spelling simplification.  This dictionary provides both a necessary reference for earlier literature (including Sila's own History of Laos), as well as the first scholarly refernece to the dvelopment of the Lao language.
+
+**[Lao-Eng Dictionary](https://small.fileditchstuff.me/s11/BgEJUJaYRMiiMVOfveZn.zip)**
+
+Usable Lao-Eng dictionary from (DaDaKo)[https://dadako.narod.ru/paperpoe.htm] site.
+
 ## English-English
 
 **[Google Drive](https://drive.google.com/drive/folders/1APj14ap2yMv0WZvSCEGJq9jfMUpZy6Ao?usp=sharing)**

--- a/readme.md
+++ b/readme.md
@@ -1460,6 +1460,8 @@ Far more than a simple compendium of definitions, Sila 1960 is filled with etymo
 
 The value of Sila 1960 continues to grow following the 1975 policy of spelling simplification.  This dictionary provides both a necessary reference for earlier literature (including Sila's own History of Laos), as well as the first scholarly refernece to the dvelopment of the Lao language.
 
+### Lao-English
+
 **[Lao-Eng Dictionary](https://small.fileditchstuff.me/s11/BgEJUJaYRMiiMVOfveZn.zip)**
 
 Usable Lao-Eng dictionary from [DaDaKo](https://dadako.narod.ru/paperpoe.htm) site.

--- a/readme.md
+++ b/readme.md
@@ -1452,7 +1452,7 @@ Note that ISO code for Lao is `lo`, please consult [List of ISO 639 language cod
 
 **[Maha Sila Viravongs 1960 Lao Dictionary](https://small.fileditchstuff.me/s11/jOxxQtOcoZsodMtnujj.zip)**
 
-(SEAlang Project)[http://sealang.net/faq/] described it as below.
+[SEAlang Project](http://sealang.net/faq/) described it as below.
 
 Maha Sila Viravongs' Dictionary of the Lao Language (Watcananukom Phaasaa Laaw), first published by the Ministry of Education in 1960, stands as the singular achievement of Lao lexicography. 
 
@@ -1462,7 +1462,7 @@ The value of Sila 1960 continues to grow following the 1975 policy of spelling s
 
 **[Lao-Eng Dictionary](https://small.fileditchstuff.me/s11/BgEJUJaYRMiiMVOfveZn.zip)**
 
-Usable Lao-Eng dictionary from (DaDaKo)[https://dadako.narod.ru/paperpoe.htm] site.
+Usable Lao-Eng dictionary from [DaDaKo](https://dadako.narod.ru/paperpoe.htm) site.
 
 ## English-English
 

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ My related dictionary resources:
   - [Japanese-Mongolian/日・モ辞典](#japanese-mongolian日モ辞典)
   - [Korean](#korean)
   - [Vietnamese-English](#vietnamese-english)
+  - [Lao](#Lao)
   - [English-English](#english-english)
   - [Other Languages](#other-languages)
 

--- a/readme.md
+++ b/readme.md
@@ -1449,7 +1449,7 @@ entries.
 
 Note that ISO code for Lao is `lo`, please consult
 [List of ISO 639 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) for
-clearification.
+clarification.
 
 #### Lao-Lao
 
@@ -1471,7 +1471,7 @@ of Laos), as well as the first scholarly refernece to the dvelopment of the Lao 
 
 **[Lao-Eng Dictionary](https://small.fileditchstuff.me/s11/BgEJUJaYRMiiMVOfveZn.zip)**
 
-Usable Lao-Eng dictionary from [DaDaKo](https://dadako.narod.ru/paperpoe.htm) site.
+Usable Lao-Eng dictionary from the [DaDaKo](https://dadako.narod.ru/paperpoe.htm) site.
 
 ## English-English
 


### PR DESCRIPTION
Add two dictionaries, which are Maha Sila Viravongs 1960 Lao Dictionary and (only one usable) Lao-Eng Dictionary from [DaDaKo](https://dadako.narod.ru/paperpoe.htm), and short descriptions.